### PR TITLE
Bring in GCC via brew

### DIFF
--- a/Formula/o2-full-deps.rb
+++ b/Formula/o2-full-deps.rb
@@ -8,6 +8,7 @@ class O2FullDeps < Formula
   depends_on "autoconf"
   depends_on "automake"
   depends_on "cmake"
+  depends_on "gcc"
   depends_on "coreutils"
   depends_on "gettext"
   depends_on "glfw3"


### PR DESCRIPTION
Since we don't have any problems bringing in gfortran via homebrew gcc, we should not ask users to install gfortran manually.