### PR TITLE
alice-build-machine: init at 20.3-1

### DIFF
--- a/Formula/alice-build-machine.rb
+++ b/Formula/alice-build-machine.rb
@@ -1,0 +1,15 @@
+class O2FullDeps < Formula
+  desc "ALICE O2 Build Machine Dependencies via Homebrew"
+  homepage "https://alisw.github.io"
+  url "file:///dev/null"
+  sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  version "20.3-1"
+
+  depends_on "alisw/system-deps/o2-full-deps"
+  depends_on "mysql"
+  depends_on "openjdk"
+
+  def install
+    system "touch", "#{prefix}/empty"
+  end
+end


### PR DESCRIPTION
Used to install extra dependencies for build machines.