### PR TITLE
Install nomad and consul on build machines

### DIFF
--- a/Formula/alice-build-machine.rb
+++ b/Formula/alice-build-machine.rb
@@ -3,11 +3,13 @@ class AliceBuildMachine < Formula
   homepage "https://alisw.github.io"
   url "file:///dev/null"
   sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-  version "20.3-1"
+  version "23.17-1"
 
   depends_on "alisw/system-deps/o2-full-deps"
   depends_on "mysql"
   depends_on "openjdk"
+  depends_on "nomad"
+  depends_on "consul"
 
   def install
     system "touch", "#{prefix}/empty"


### PR DESCRIPTION
...so I don't have to install them manually.

@ktf, are mysql and openjdk still required or can I remove them?